### PR TITLE
Remove debug logging from internal/congestion/bandwidth_sampler

### DIFF
--- a/internal/congestion/bandwidth_sampler.go
+++ b/internal/congestion/bandwidth_sampler.go
@@ -100,7 +100,6 @@ func (s *BandwidthSampler) OnPacketAcknowledged(ackTime time.Time,
 
 	sentPacketState := s.connectionStateMap[packetNumber]
 	if sentPacketState == nil {
-		log.Printf("£ yup, it's nil")
 		return BandwidthSample{
 			Bandwidth:    0,
 			RTT:          -1,
@@ -135,7 +134,6 @@ func (s *BandwidthSampler) OnPacketAcknowledgedInner(ackTime time.Time,
 	if sentPacketState.lastAckedPacketSentTime.IsZero() {
 		return BandwidthSample{}
 	}
-	log.Printf("£ Sanity check %v", sentPacketState.lastAckedPacketSentTime)
 
 	// Infinite rate indicates that the sampler is supposed to discard the
 	// current send rate sample and use only the ack rate.


### PR DESCRIPTION
Forgot to take these out before submitting the "final" POC PR. Woops.

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [x] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?